### PR TITLE
init base framework

### DIFF
--- a/SpeakUp/SpeakUp.xcodeproj/project.pbxproj
+++ b/SpeakUp/SpeakUp.xcodeproj/project.pbxproj
@@ -1,0 +1,360 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		277F8A6D2C0F9A70005A8A8F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 277F8A6C2C0F9A70005A8A8F /* AppDelegate.swift */; };
+		277F8A702C0F9A70005A8A8F /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 277F8A6F2C0F9A70005A8A8F /* SceneDelegate.swift */; };
+		277F8A732C0F9A70005A8A8F /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 277F8A722C0F9A70005A8A8F /* ViewController.swift */; };
+		277F8A772C0F9A7C005A8A8F /* PersistenceController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 277F8A762C0F9A7C005A8A8F /* PersistenceController.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		277F8A692C0F9A70005A8A8F /* SpeakUp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SpeakUp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		277F8A6C2C0F9A70005A8A8F /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		277F8A6F2C0F9A70005A8A8F /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		277F8A722C0F9A70005A8A8F /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		277F8A752C0F9A7C005A8A8F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		277F8A762C0F9A7C005A8A8F /* PersistenceController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceController.swift; sourceTree = "<group>"; };
+		277F8A792C0F9A7C005A8A8F /* SpeakUp.xcdatamodeld */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; name = SpeakUp.xcdatamodeld; path = SpeakUp/Models/CoreData/SpeakUp.xcdatamodeld; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXGroup section */
+		277F8A682C0F9A70005A8A8F = {
+			isa = PBXGroup;
+			children = (
+				277F8A6B2C0F9A70005A8A8F /* SpeakUp */,
+				277F8A6A2C0F9A70005A8A8F /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		277F8A6A2C0F9A70005A8A8F /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				277F8A692C0F9A70005A8A8F /* SpeakUp.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		277F8A6B2C0F9A70005A8A8F /* SpeakUp */ = {
+			isa = PBXGroup;
+			children = (
+				277F8A6C2C0F9A70005A8A8F /* AppDelegate.swift */,
+				277F8A6F2C0F9A70005A8A8F /* SceneDelegate.swift */,
+				277F8A722C0F9A70005A8A8F /* ViewController.swift */,
+				277F8A782C0F9A7C005A8A8F /* Models */,
+				277F8A742C0F9A7C005A8A8F /* SupportingFiles */,
+			);
+			path = SpeakUp;
+			sourceTree = "<group>";
+		};
+		277F8A742C0F9A7C005A8A8F /* SupportingFiles */ = {
+			isa = PBXGroup;
+			children = (
+				277F8A752C0F9A7C005A8A8F /* Info.plist */,
+			);
+			name = SupportingFiles;
+			path = SpeakUp/SupportingFiles;
+			sourceTree = "<group>";
+		};
+		277F8A782C0F9A7C005A8A8F /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				277F8A7A2C0F9A7C005A8A8F /* CoreData */,
+			);
+			name = Models;
+			path = SpeakUp/Models;
+			sourceTree = "<group>";
+		};
+		277F8A7A2C0F9A7C005A8A8F /* CoreData */ = {
+			isa = PBXGroup;
+			children = (
+				277F8A792C0F9A7C005A8A8F /* SpeakUp.xcdatamodeld */,
+				277F8A762C0F9A7C005A8A8F /* PersistenceController.swift */,
+			);
+			name = CoreData;
+			path = SpeakUp/Models/CoreData;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		277F8A7B2C0F9A7C005A8A8F /* SpeakUp */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 277F8A8E2C0F9A7C005A8A8F /* Build configuration list for PBXNativeTarget "SpeakUp" */;
+			buildPhases = (
+				277F8A8B2C0F9A7C005A8A8F /* Sources */,
+				277F8A8C2C0F9A7C005A8A8F /* Frameworks */,
+				277F8A8D2C0F9A7C005A8A8F /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = SpeakUp;
+			productName = SpeakUp;
+			productReference = 277F8A692C0F9A70005A8A8F /* SpeakUp.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		277F8A7C2C0F9A7C005A8A8F /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 1320;
+				LastUpgradeCheck = 1320;
+				ORGANIZATIONNAME = "YourCompany";
+				TargetAttributes = {
+					277F8A7B2C0F9A7C005A8A8F = {
+						CreatedOnToolsVersion = 13.2.1;
+						ProvisioningStyle = Automatic;
+					};
+				};
+			};
+			buildConfigurationList = 277F8A7F2C0F9A7C005A8A8F /* Build configuration list for PBXProject "SpeakUp" */;
+			compatibilityVersion = "Xcode 13.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 277F8A682C0F9A70005A8A8F;
+			productRefGroup = 277F8A6A2C0F9A70005A8A8F /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				277F8A7B2C0F9A7C005A8A8F /* SpeakUp */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		277F8A8B2C0F9A7C005A8A8F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				277F8A772C0F9A7C005A8A8F /* PersistenceController.swift in Sources */,
+				277F8A6D2C0F9A70005A8A8F /* AppDelegate.swift in Sources */,
+				277F8A732C0F9A70005A8A8F /* ViewController.swift in Sources */,
+				277F8A702C0F9A70005A8A8F /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		277F8A8C2C0F9A7C005A8A8F /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXResourcesBuildPhase section */
+		277F8A8D2C0F9A7C005A8A8F /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				277F8A792C0F9A7C005A8A8F /* SpeakUp.xcdatamodeld */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		277F8A892C0F9A7C005A8A8F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		277F8A8A2C0F9A7C005A8A8F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		277F8A902C0F9A7C005A8A8F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = SpeakUp/SupportingFiles/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.example.SpeakUp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		277F8A912C0F9A7C005A8A8F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = SpeakUp/SupportingFiles/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.example.SpeakUp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		277F8A7F2C0F9A7C005A8A8F /* Build configuration list for PBXProject "SpeakUp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				277F8A892C0F9A7C005A8A8F /* Debug */,
+				277F8A8A2C0F9A7C005A8A8F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		277F8A8E2C0F9A7C005A8A8F /* Build configuration list for PBXNativeTarget "SpeakUp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				277F8A902C0F9A7C005A8A8F /* Debug */,
+				277F8A912C0F9A7C005A8A8F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 277F8A7C2C0F9A7C005A8A8F /* Project object */;
+}

--- a/SpeakUp/SpeakUp/Models/CoreData/PersistenceController.swift
+++ b/SpeakUp/SpeakUp/Models/CoreData/PersistenceController.swift
@@ -1,0 +1,31 @@
+import CoreData
+
+struct PersistenceController {
+    static let shared = PersistenceController()
+
+    let container: NSPersistentContainer
+
+    init(inMemory: Bool = false) {
+        container = NSPersistentContainer(name: "SpeakUp")
+        if inMemory {
+            container.persistentStoreDescriptions.first!.url = URL(fileURLWithPath: "/dev/null")
+        }
+        container.loadPersistentStores(completionHandler: { (storeDescription, error) in
+            if let error = error as NSError? {
+                // Replace this implementation with code to handle the error appropriately.
+                // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
+
+                /*
+                 Typical reasons for an error here include:
+                 * The parent directory does not exist, cannot be created, or disallows writing.
+                 * The persistent store is not accessible, due to permissions or data protection when the device is locked.
+                 * The device is out of space.
+                 * The store could not be migrated to the current model version.
+                 Check the error message to determine what the actual problem was.
+                 */
+                fatalError("Unresolved error \(error), \(error.userInfo)")
+            }
+        })
+        container.viewContext.automaticallyMergesChangesFromParent = true
+    }
+}

--- a/SpeakUp/SpeakUp/Models/CoreData/SpeakUp.xcdatamodeld/contents
+++ b/SpeakUp/SpeakUp/Models/CoreData/SpeakUp.xcdatamodeld/contents
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model name="SpeakUp" userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22608" systemVersion="23E214" minimumToolsVersion="12.0">
+    <entity name="PracticeText" representedClassName="PracticeText" syncable="YES">
+        <attribute name="id" attributeType="UUID" usesScalarValueType="NO" nonOptional="YES" syncable="YES"/>
+        <attribute name="title" attributeType="String" usesScalarValueType="NO" nonOptional="YES" syncable="YES"/>
+        <attribute name="content" attributeType="String" usesScalarValueType="NO" nonOptional="YES" syncable="YES"/>
+        <attribute name="createdAt" attributeType="Date" usesScalarValueType="NO" nonOptional="YES" syncable="YES"/>
+        <attribute name="lastPracticedAt" attributeType="Date" usesScalarValueType="NO" optional="YES" syncable="YES"/>
+        <attribute name="practiceCount" attributeType="Integer 16" usesScalarValueType="YES" nonOptional="YES" defaultValueString="0" syncable="YES"/>
+        <relationship name="recordings" destinationEntity="Recording" toMany="YES" deletionRule="Cascade" inverseName="practiceText" inverseEntity="Recording" syncable="YES"/>
+    </entity>
+    <entity name="Recording" representedClassName="Recording" syncable="YES">
+        <attribute name="id" attributeType="UUID" usesScalarValueType="NO" nonOptional="YES" syncable="YES"/>
+        <attribute name="fileURL" attributeType="URL" usesScalarValueType="NO" nonOptional="YES" syncable="YES"/>
+        <attribute name="duration" attributeType="Double" usesScalarValueType="YES" nonOptional="YES" syncable="YES"/>
+        <attribute name="createdAt" attributeType="Date" usesScalarValueType="NO" nonOptional="YES" syncable="YES"/>
+        <relationship name="practiceText" destinationEntity="PracticeText" toMany="NO" deletionRule="Nullify" inverseName="recordings" inverseEntity="PracticeText" syncable="YES"/>
+    </entity>
+</model>

--- a/SpeakUp/SpeakUp/Models/Repository/RecordingRepository.swift
+++ b/SpeakUp/SpeakUp/Models/Repository/RecordingRepository.swift
@@ -1,0 +1,107 @@
+import CoreData
+import Foundation // For FileManager
+
+class RecordingRepository {
+    private let viewContext: NSManagedObjectContext
+    private let textRepository: TextRepository // To fetch PracticeText
+
+    init(persistenceController: PersistenceController = PersistenceController.shared, textRepository: TextRepository = TextRepository()) {
+        self.viewContext = persistenceController.container.viewContext
+        self.textRepository = textRepository
+    }
+
+    func saveRecording(fileURL: URL, duration: Double, textID: UUID) -> Recording? {
+        guard let practiceText = textRepository.getPracticeText(byID: textID) else {
+            print("Error: Could not find PracticeText with ID \(textID) to associate with the recording.")
+            return nil
+        }
+
+        let newRecording = Recording(context: viewContext)
+        newRecording.id = UUID()
+        newRecording.fileURL = fileURL
+        newRecording.duration = duration
+        newRecording.createdAt = Date()
+        newRecording.practiceText = practiceText
+        
+        // Update practice text stats
+        textRepository.updatePracticeTextStats(textID: textID, lastPracticedAt: Date())
+
+        do {
+            try viewContext.save()
+            print("Successfully saved recording for text ID: \(textID) at \(fileURL.path)")
+            return newRecording
+        } catch {
+            // Replace this implementation with code to handle the error appropriately.
+            let nsError = error as NSError
+            print("Unresolved error \(nsError), \(nsError.userInfo) while saving recording.")
+            // It might be good to delete the audio file if DB save fails
+            // For now, we'll just report the error.
+            return nil
+        }
+    }
+
+    func fetchAllRecordings(sortByCreatedAt ascending: Bool = false) -> [Recording] {
+        let fetchRequest: NSFetchRequest<Recording> = Recording.fetchRequest()
+        
+        let sortDescriptor = NSSortDescriptor(keyPath: \Recording.createdAt, ascending: ascending)
+        fetchRequest.sortDescriptors = [sortDescriptor]
+        
+        do {
+            let recordings = try viewContext.fetch(fetchRequest)
+            return recordings
+        } catch {
+            print("Failed to fetch recordings: \(error)")
+            return []
+        }
+    }
+    
+    func fetchRecordings(forTextID textID: UUID, sortByCreatedAt ascending: Bool = false) -> [Recording] {
+        let fetchRequest: NSFetchRequest<Recording> = Recording.fetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "practiceText.id == %@", textID as CVarArg)
+        
+        let sortDescriptor = NSSortDescriptor(keyPath: \Recording.createdAt, ascending: ascending)
+        fetchRequest.sortDescriptors = [sortDescriptor]
+        
+        do {
+            let recordings = try viewContext.fetch(fetchRequest)
+            return recordings
+        } catch {
+            print("Failed to fetch recordings for text ID \(textID): \(error)")
+            return []
+        }
+    }
+
+    func deleteRecording(recordingID: UUID) {
+        let fetchRequest: NSFetchRequest<Recording> = Recording.fetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "id == %@", recordingID as CVarArg)
+        
+        do {
+            guard let recordingToDelete = try viewContext.fetch(fetchRequest).first else {
+                print("Recording with ID \(recordingID) not found.")
+                return
+            }
+            
+            // Delete the audio file from disk
+            if let fileURL = recordingToDelete.fileURL {
+                do {
+                    try FileManager.default.removeItem(at: fileURL)
+                    print("Successfully deleted audio file: \(fileURL.path)")
+                } catch {
+                    print("Error deleting audio file \(fileURL.path): \(error)")
+                    // Proceed with deleting the Core Data entry even if file deletion fails,
+                    // as the file might not exist or there might be permission issues.
+                }
+            }
+            
+            // Delete the Recording object from Core Data
+            viewContext.delete(recordingToDelete)
+            
+            try viewContext.save()
+            print("Successfully deleted recording with ID: \(recordingID)")
+            
+        } catch {
+            print("Failed to delete recording with ID \(recordingID): \(error)")
+            // Handle the error appropriately
+        }
+    }
+}

--- a/SpeakUp/SpeakUp/Models/Repository/TextRepository.swift
+++ b/SpeakUp/SpeakUp/Models/Repository/TextRepository.swift
@@ -1,0 +1,101 @@
+import CoreData
+import UIKit // Required for UIApplication delegate access for context
+
+class TextRepository {
+    private let viewContext: NSManagedObjectContext
+
+    init(persistenceController: PersistenceController = PersistenceController.shared) {
+        self.viewContext = persistenceController.container.viewContext
+    }
+
+    func importSampleTexts() {
+        let fetchRequest: NSFetchRequest<PracticeText> = PracticeText.fetchRequest()
+        
+        do {
+            let existingTexts = try viewContext.fetch(fetchRequest)
+            guard existingTexts.isEmpty else {
+                print("Sample texts already exist. Skipping import.")
+                return
+            }
+        } catch {
+            print("Error fetching existing texts: \(error)")
+            // Decide if we should proceed or not, for now, we'll proceed if fetch fails
+        }
+
+        let sampleTexts = [
+            ("Greeting", "Hello world. This is a sample text for practice."),
+            ("Proverb", "Practice makes perfect. Repeat this line several times."),
+            ("Affirmation", "I am confident in my ability to speak clearly and effectively.")
+        ]
+
+        for (index, (title, content)) in sampleTexts.enumerated() {
+            let newText = PracticeText(context: viewContext)
+            newText.id = UUID()
+            newText.title = "\(title) (Sample \(index + 1))"
+            newText.content = content
+            newText.createdAt = Date()
+            newText.practiceCount = 0
+            newText.lastPracticedAt = nil // Initially not practiced
+        }
+
+        do {
+            try viewContext.save()
+            print("Successfully imported sample texts.")
+        } catch {
+            // Replace this implementation with code to handle the error appropriately.
+            let nsError = error as NSError
+            fatalError("Unresolved error \(nsError), \(nsError.userInfo)")
+        }
+    }
+
+    func fetchAllTexts(sortByCreatedAt ascending: Bool = true) -> [PracticeText] {
+        let fetchRequest: NSFetchRequest<PracticeText> = PracticeText.fetchRequest()
+        
+        let sortDescriptor = NSSortDescriptor(keyPath: \PracticeText.createdAt, ascending: ascending)
+        fetchRequest.sortDescriptors = [sortDescriptor]
+        
+        do {
+            let texts = try viewContext.fetch(fetchRequest)
+            return texts
+        } catch {
+            print("Failed to fetch texts: \(error)")
+            return []
+        }
+    }
+
+    func updatePracticeTextStats(textID: UUID, lastPracticedAt: Date) {
+        let fetchRequest: NSFetchRequest<PracticeText> = PracticeText.fetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "id == %@", textID as CVarArg)
+        
+        do {
+            let texts = try viewContext.fetch(fetchRequest)
+            guard let textToUpdate = texts.first else {
+                print("PracticeText with ID \(textID) not found.")
+                return
+            }
+            
+            textToUpdate.lastPracticedAt = lastPracticedAt
+            textToUpdate.practiceCount += 1
+            
+            try viewContext.save()
+            print("Successfully updated practice text stats for ID: \(textID)")
+        } catch {
+            print("Failed to update PracticeText stats for ID \(textID): \(error)")
+            // Handle the error appropriately
+        }
+    }
+    
+    func getPracticeText(byID id: UUID) -> PracticeText? {
+        let fetchRequest: NSFetchRequest<PracticeText> = PracticeText.fetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "id == %@", id as CVarArg)
+        fetchRequest.fetchLimit = 1
+        
+        do {
+            let results = try viewContext.fetch(fetchRequest)
+            return results.first
+        } catch {
+            print("Error fetching PracticeText with ID \(id): \(error)")
+            return nil
+        }
+    }
+}

--- a/SpeakUp/SpeakUp/Models/Service/AudioService.swift
+++ b/SpeakUp/SpeakUp/Models/Service/AudioService.swift
@@ -1,0 +1,199 @@
+import AVFoundation
+import UIKit // For UIDevice
+
+class AudioService: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate {
+    private var audioRecorder: AVAudioRecorder?
+    private var audioPlayer: AVAudioPlayer?
+    private var recordingContinuation: CheckedContinuation<URL, Error>?
+    private var playbackContinuation: CheckedContinuation<Void, Error>?
+    
+    // Weak reference to the ViewModel to notify about recording completion.
+    // This is a simplification for MVP. A delegate pattern would be cleaner.
+    weak var practiceViewModel: PracticeViewModel? 
+
+    override init() {
+        super.init()
+        setupAudioSession()
+    }
+
+    func setupAudioSession() {
+        let audioSession = AVAudioSession.sharedInstance()
+        do {
+            // Set category to playAndRecord to allow both recording and playback.
+            // .defaultToSpeaker option ensures playback is through the speaker even if headphones are not connected.
+            // .allowBluetoothA2DP allows for playback on Bluetooth audio devices if available.
+            try audioSession.setCategory(.playAndRecord, mode: .default, options: [.defaultToSpeaker, .allowBluetoothA2DP])
+            try audioSession.setActive(true)
+            print("Audio session configured and activated.")
+        } catch {
+            // Handle error (e.g., print error, show alert to user)
+            print("Failed to set up audio session: \(error)")
+        }
+    }
+
+    func startRecording() async throws -> URL {
+        return try await withCheckedThrowingContinuation { continuation in
+            self.recordingContinuation = continuation
+            
+            let audioFilename = getDocumentsDirectory().appendingPathComponent("\(UUID().uuidString).m4a")
+
+            let settings = [
+                AVFormatIDKey: Int(kAudioFormatMPEG4AAC),
+                AVSampleRateKey: 12000, // Standard sample rate
+                AVNumberOfChannelsKey: 1, // Mono recording
+                AVEncoderAudioQualityKey: AVAudioQuality.high.rawValue // High quality
+            ]
+
+            do {
+                audioRecorder = try AVAudioRecorder(url: audioFilename, settings: settings)
+                audioRecorder?.delegate = self // Delegate to handle recording events
+                audioRecorder?.isMeteringEnabled = true // Enable audio metering
+                audioRecorder?.record() // Start recording
+                print("Recording started at URL: \(audioFilename)")
+            } catch {
+                print("Could not start recording: \(error)")
+                continuation.resume(throwing: error)
+                self.recordingContinuation = nil
+            }
+        }
+    }
+
+    func stopRecording() {
+        audioRecorder?.stop()
+        // The actual URL is returned via the delegate method audioRecorderDidFinishRecording
+        print("Recording stopped.")
+    }
+
+    func playRecording(url: URL) async throws {
+        // Ensure audio session is active and configured for playback
+        let audioSession = AVAudioSession.sharedInstance()
+        do {
+            try audioSession.setCategory(.playback, mode: .default, options: [.defaultToSpeaker])
+            try audioSession.setActive(true)
+        } catch {
+            print("Failed to set up audio session for playback: \(error)")
+            throw error // Propagate the error
+        }
+        
+        // Check if the file exists
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            print("Audio file not found at URL: \(url.path)")
+            throw NSError(domain: "AudioServiceError", code: 404, userInfo: [NSLocalizedDescriptionKey: "Audio file not found."])
+        }
+
+        return try await withCheckedThrowingContinuation { continuation in
+            self.playbackContinuation = continuation
+            do {
+                // For iOS 15+, check if device is muted (silent switch)
+                // This is a simplified check. For more robust handling, you might need more complex logic.
+                if #available(iOS 15.0, *) {
+                    if audioSession.isOtherAudioPlaying && audioSession.secondaryAudioShouldBeSilencedHint {
+                         print("Other audio is playing and should be silenced. Playback might be muted.")
+                    }
+                    if audioSession.outputVolume == 0 {
+                        print("Device is muted. Playback might not be audible.")
+                        // You could potentially alert the user here or handle it as an error.
+                        // For now, we'll proceed with playback.
+                    }
+                }
+
+
+                audioPlayer = try AVAudioPlayer(contentsOf: url)
+                audioPlayer?.delegate = self
+                audioPlayer?.play()
+                print("Playback started for URL: \(url.path)")
+            } catch {
+                print("Could not play recording: \(error)")
+                continuation.resume(throwing: error)
+                self.playbackContinuation = nil
+            }
+        }
+    }
+
+    func stopPlaying() {
+        audioPlayer?.stop()
+        playbackContinuation?.resume(throwing: CancellationError()) // Indicate playback was stopped
+        playbackContinuation = nil
+        print("Playback stopped.")
+        // It's good practice to deactivate the audio session or reset its category
+        // if the app is not actively using audio, to allow other apps to use it.
+        // However, for simplicity in this MVP, we might leave it active.
+        // Consider deactivating or resetting category in a real app.
+        // For example:
+        // do {
+        //     try AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+        // } catch {
+        //     print("Failed to deactivate audio session: \(error)")
+        // }
+    }
+
+    private func getDocumentsDirectory() -> URL {
+        let paths = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)
+        return paths[0]
+    }
+
+    // MARK: - AVAudioRecorderDelegate
+    func audioRecorderDidFinishRecording(_ recorder: AVAudioRecorder, successfully flag: Bool) {
+        // Notify the ViewModel first
+        if let viewModel = practiceViewModel {
+            DispatchQueue.main.async { // Ensure UI updates are on the main thread
+                viewModel.recordingFinished(url: recorder.url, successfully: flag)
+            }
+        }
+
+        if flag {
+            recordingContinuation?.resume(returning: recorder.url)
+            print("AudioRecorder finished successfully. URL: \(recorder.url)")
+        } else {
+            // Recording failed or was stopped before completion (e.g. by an interruption)
+            recordingContinuation?.resume(throwing: NSError(domain: "AudioServiceError", code: 1, userInfo: [NSLocalizedDescriptionKey: "Recording failed or was interrupted."]))
+            print("AudioRecorder finished unsuccessfully.")
+        }
+        recordingContinuation = nil
+        audioRecorder = nil // Release the recorder instance
+    }
+
+    func audioRecorderEncodeErrorDidOccur(_ recorder: AVAudioRecorder, error: Error?) {
+        // Notify the ViewModel about the error
+        if let viewModel = practiceViewModel {
+            DispatchQueue.main.async {
+                viewModel.recordingFinished(url: recorder.url, successfully: false) // Indicate failure
+            }
+        }
+
+        if let error = error {
+            recordingContinuation?.resume(throwing: error)
+            print("AudioRecorder encode error: \(error.localizedDescription)")
+        } else {
+            recordingContinuation?.resume(throwing: NSError(domain: "AudioServiceError", code: 2, userInfo: [NSLocalizedDescriptionKey: "Unknown recording encode error."]))
+            print("AudioRecorder encode error (unknown).")
+        }
+        recordingContinuation = nil
+        audioRecorder = nil
+    }
+
+    // MARK: - AVAudioPlayerDelegate
+    func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
+        if flag {
+            playbackContinuation?.resume(returning: ())
+            print("AudioPlayer finished playing successfully.")
+        } else {
+            playbackContinuation?.resume(throwing: NSError(domain: "AudioServiceError", code: 3, userInfo: [NSLocalizedDescriptionKey: "Playback failed or was interrupted."]))
+            print("AudioPlayer finished playing unsuccessfully.")
+        }
+        playbackContinuation = nil
+        audioPlayer = nil // Release the player instance
+    }
+
+    func audioPlayerDecodeErrorDidOccur(_ player: AVAudioPlayer, error: Error?) {
+        if let error = error {
+            playbackContinuation?.resume(throwing: error)
+            print("AudioPlayer decode error: \(error.localizedDescription)")
+        } else {
+            playbackContinuation?.resume(throwing: NSError(domain: "AudioServiceError", code: 4, userInfo: [NSLocalizedDescriptionKey: "Unknown playback decode error."]))
+            print("AudioPlayer decode error (unknown).")
+        }
+        playbackContinuation = nil
+        audioPlayer = nil
+    }
+}

--- a/SpeakUp/SpeakUp/SupportingFiles/AppDelegate.swift
+++ b/SpeakUp/SpeakUp/SupportingFiles/AppDelegate.swift
@@ -1,0 +1,57 @@
+import UIKit
+import CoreData
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+    var window: UIWindow?
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        // Override point for customization after application launch.
+        let persistenceController = PersistenceController.shared
+        print("App did finish launching. Core Data container loaded: \(persistenceController.container.name)")
+        
+        // Import sample texts
+        let textRepository = TextRepository(persistenceController: persistenceController)
+        textRepository.importSampleTexts()
+        
+        return true
+    }
+
+    // MARK: UISceneSession Lifecycle
+
+    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        // Called when a new scene session is being created.
+        // Use this method to select a configuration to create the new scene with.
+        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    }
+
+    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
+        // Called when the user discards a scene session.
+        // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
+        // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
+    }
+
+    // MARK: - Core Data stack
+
+    lazy var persistentContainer: NSPersistentContainer = {
+        let container = PersistenceController.shared.container
+        return container
+    }()
+
+    // MARK: - Core Data Saving support
+
+    func saveContext () {
+        let context = persistentContainer.viewContext
+        if context.hasChanges {
+            do {
+                try context.save()
+            } catch {
+                // Replace this implementation with code to handle the error appropriately.
+                // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
+                let nserror = error as NSError
+                fatalError("Unresolved error \(nserror), \(nserror.userInfo)")
+            }
+        }
+    }
+}

--- a/SpeakUp/SpeakUp/SupportingFiles/Info.plist
+++ b/SpeakUp/SpeakUp/SupportingFiles/Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+	<key>UILaunchScreen</key>
+	<dict/>
+</dict>
+</plist>

--- a/SpeakUp/SpeakUp/SupportingFiles/SceneDelegate.swift
+++ b/SpeakUp/SpeakUp/SupportingFiles/SceneDelegate.swift
@@ -1,0 +1,67 @@
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+    var window: UIWindow?
+
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
+        // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
+        // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
+        guard let windowScene = (scene as? UIWindowScene) else { return }
+        
+        let window = UIWindow(windowScene: windowScene)
+        
+        // Setup Core Services and Repositories
+        let persistenceController = PersistenceController.shared // Already initialized in AppDelegate
+        let textRepository = TextRepository(persistenceController: persistenceController)
+        let audioService = AudioService() // Has its own setup
+        let recordingRepository = RecordingRepository(persistenceController: persistenceController, textRepository: textRepository)
+
+        // Setup HomeViewModel and HomeViewController
+        let homeViewModel = HomeViewModel(
+            textRepository: textRepository,
+            audioService: audioService,
+            recordingRepository: recordingRepository
+        )
+        let homeViewController = HomeViewController(viewModel: homeViewModel)
+        
+        // Embed in a UINavigationController
+        let navigationController = UINavigationController(rootViewController: homeViewController)
+        
+        window.rootViewController = navigationController
+        self.window = window
+        window.makeKeyAndVisible()
+    }
+
+    func sceneDidDisconnect(_ scene: UIScene) {
+        // Called as the scene is being released by the system.
+        // This occurs shortly after the scene enters the background, or when its session is discarded.
+        // Release any resources associated with this scene that can be re-created the next time the scene connects.
+        // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
+    }
+
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        // Called when the scene has moved from an inactive state to an active state.
+        // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+    }
+
+    func sceneWillResignActive(_ scene: UIScene) {
+        // Called when the scene will move from an active state to an inactive state.
+        // This may occur due to temporary interruptions (ex. an incoming phone call).
+    }
+
+    func sceneWillEnterForeground(_ scene: UIScene) {
+        // Called as the scene transitions from the background to the foreground.
+        // Use this method to undo the changes made on entering the background.
+    }
+
+    func sceneDidEnterBackground(_ scene: UIScene) {
+        // Called as the scene transitions from the foreground to the background.
+        // Use this method to save data, release shared resources, and store enough scene-specific state information
+        // to restore the scene back to its current state.
+
+        // Save changes in the application's managed object context when the application transitions to the background.
+        (UIApplication.shared.delegate as? AppDelegate)?.saveContext()
+    }
+}

--- a/SpeakUp/SpeakUp/ViewController.swift
+++ b/SpeakUp/SpeakUp/ViewController.swift
@@ -1,0 +1,24 @@
+import UIKit
+
+class ViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        // Do any additional setup after loading the view.
+        self.view.backgroundColor = .white // Basic setup
+        
+        let label = UILabel()
+        label.text = "SpeakUp MVP"
+        label.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(label)
+        
+        NSLayoutConstraint.activate([
+            label.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            label.centerYAnchor.constraint(equalTo: view.centerYAnchor)
+        ])
+        
+        // Test Core Data initialization
+        let context = (UIApplication.shared.delegate as! AppDelegate).persistentContainer.viewContext
+        print("Main view controller loaded. Core Data context obtained: \(context)")
+    }
+}

--- a/SpeakUp/SpeakUp/Views/Home/HomeViewController.swift
+++ b/SpeakUp/SpeakUp/Views/Home/HomeViewController.swift
@@ -1,0 +1,119 @@
+import UIKit
+
+class HomeViewController: UIViewController, UITableViewDataSource, UITableViewDelegate {
+
+    private var viewModel: HomeViewModel! // Will be set by SceneDelegate or AppDelegate
+
+    // UI Elements
+    private let tableView: UITableView = {
+        let tableView = UITableView()
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: "PracticeTextCell")
+        return tableView
+    }()
+
+    // Convenience init for programmatic setup (e.g., in SceneDelegate)
+    init(viewModel: HomeViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        // This would be used if initializing from a Storyboard, which we are not for this MVP.
+        // If this were ever needed, the viewModel would have to be injected differently.
+        fatalError("init(coder:) has not been implemented. Use init(viewModel:) instead.")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .white
+        title = "SpeakUp - Practice Texts" // Navigation bar title
+        setupUI()
+        setupViewModel()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        viewModel.fetchPracticeTexts() // Fetch texts every time the view appears
+    }
+
+    private func setupUI() {
+        view.addSubview(tableView)
+        tableView.dataSource = self
+        tableView.delegate = self
+
+        NSLayoutConstraint.activate([
+            tableView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
+        ])
+    }
+
+    private func setupViewModel() {
+        viewModel.onDataReload = { [weak self] in
+            self?.tableView.reloadData()
+        }
+        
+        viewModel.onError = { [weak self] error in
+            // Simple alert for errors
+            let alert = UIAlertController(title: "Error", message: error.localizedDescription, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: "OK", style: .default))
+            self?.present(alert, animated: true)
+        }
+    }
+
+    // MARK: - UITableViewDataSource
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return viewModel.practiceTexts.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "PracticeTextCell", for: indexPath)
+        guard let practiceText = viewModel.getPracticeText(at: indexPath.row) else {
+            // Return a default or empty cell if data is not available
+            cell.textLabel?.text = "Error loading text"
+            return cell
+        }
+        cell.textLabel?.text = practiceText.title
+        cell.accessoryType = .disclosureIndicator // Indicate tappable cell
+        return cell
+    }
+
+    // MARK: - UITableViewDelegate
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        
+        guard let selectedText = viewModel.getPracticeText(at: indexPath.row) else {
+            print("Error: Could not retrieve selected practice text.")
+            // Optionally show an error to the user
+            let errorAlert = UIAlertController(title: "Error", message: "Could not load the selected practice text.", preferredStyle: .alert)
+            errorAlert.addAction(UIAlertAction(title: "OK", style: .default))
+            present(errorAlert, animated: true)
+            return
+        }
+        
+        // Create PracticeViewController and its ViewModel
+        // The HomeViewModel holds instances of services needed by PracticeViewModel
+        let practiceViewModel = PracticeViewModel(
+            practiceText: selectedText,
+            audioService: viewModel.audioService, // Pass the existing AudioService instance
+            recordingRepository: viewModel.recordingRepository, // Pass the existing RecordingRepository instance
+            textRepository: TextRepository() // PracticeViewModel can instantiate its own TextRepo if needed, or it can be passed
+        )
+        
+        let practiceVC = PracticeViewController()
+        practiceVC.practiceText = selectedText // Set the text, which will also set up its own ViewModel.
+                                              // Or, directly set the viewModel:
+                                              // practiceVC.viewModel = practiceViewModel (if PracticeVC's viewModel is public)
+                                              // For current setup, setting practiceText is the trigger.
+
+        // Ensure the AudioService's practiceViewModel delegate is correctly set to the new PracticeViewModel
+        // This is crucial because AudioService has a weak var practiceViewModel.
+        // When PracticeViewController sets its own viewModel, it also sets it on the AudioService.
+        // (viewModel.audioService as? AudioService)?.practiceViewModel = practiceViewModel 
+        // ^This line is handled inside PracticeViewController when practiceText is set.
+
+        navigationController?.pushViewController(practiceVC, animated: true)
+    }
+}

--- a/SpeakUp/SpeakUp/Views/Home/HomeViewModel.swift
+++ b/SpeakUp/SpeakUp/Views/Home/HomeViewModel.swift
@@ -1,0 +1,43 @@
+import Foundation
+import Combine // For @Published or ObservableObject
+
+class HomeViewModel: ObservableObject {
+    private let textRepository: TextRepository
+    // Keep references to services needed by PracticeViewModel to pass them along
+    let audioService: AudioService
+    let recordingRepository: RecordingRepository
+
+    // @Published can be used for SwiftUI, or a simple array for UIKit with manual updates
+    @Published var practiceTexts: [PracticeText] = []
+    
+    var onError: ((Error) -> Void)?
+    var onDataReload: (() -> Void)? // To tell the ViewController to reload its table view
+
+    init(textRepository: TextRepository = TextRepository(),
+         audioService: AudioService = AudioService(),
+         recordingRepository: RecordingRepository = RecordingRepository()) {
+        self.textRepository = textRepository
+        self.audioService = audioService
+        self.recordingRepository = recordingRepository
+    }
+
+    func fetchPracticeTexts() {
+        let texts = textRepository.fetchAllTexts(sortByCreatedAt: true) // Sort by creation date, or make it configurable
+        // Update on the main thread if this can be called from a background thread
+        DispatchQueue.main.async {
+            self.practiceTexts = texts
+            self.onDataReload?() // Notify ViewController to reload data
+            if texts.isEmpty {
+                print("No practice texts found. The list will be empty.")
+                // Optionally, could use onError to inform user if this is unexpected
+            }
+        }
+    }
+    
+    func getPracticeText(at index: Int) -> PracticeText? {
+        guard index >= 0 && index < practiceTexts.count else {
+            return nil
+        }
+        return practiceTexts[index]
+    }
+}

--- a/SpeakUp/SpeakUp/Views/Practice/PracticeViewController.swift
+++ b/SpeakUp/SpeakUp/Views/Practice/PracticeViewController.swift
@@ -1,0 +1,257 @@
+import UIKit
+import AVFoundation // For AVAudioSession for permission check
+
+class PracticeViewController: UIViewController {
+
+    var practiceText: PracticeText? {
+        didSet {
+            if let text = practiceText {
+                viewModel = PracticeViewModel(practiceText: text)
+                // Setup AudioService delegate to point to this new ViewModel instance.
+                // This is important if PracticeViewController can be reused with different practiceTexts.
+                (viewModel?.audioService as? AudioService)?.practiceViewModel = viewModel
+            }
+            configureViewForPracticeText()
+        }
+    }
+    
+    private var viewModel: PracticeViewModel?
+
+    // UI Elements
+    private let practiceTextView: UITextView = {
+        let textView = UITextView()
+        textView.isEditable = false
+        textView.font = UIFont.systemFont(ofSize: 18)
+        textView.translatesAutoresizingMaskIntoConstraints = false
+        textView.layer.borderColor = UIColor.lightGray.cgColor
+        textView.layer.borderWidth = 1.0
+        textView.layer.cornerRadius = 8.0
+        return textView
+    }()
+
+    private let recordButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle("Record", for: .normal)
+        button.titleLabel?.font = UIFont.boldSystemFont(ofSize: 18)
+        button.backgroundColor = .systemRed
+        button.setTitleColor(.white, for: .normal)
+        button.layer.cornerRadius = 8
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+
+    private let playButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle("Play Last Recording", for: .normal)
+        button.titleLabel?.font = UIFont.systemFont(ofSize: 16)
+        button.backgroundColor = .systemBlue
+        button.setTitleColor(.white, for: .normal)
+        button.layer.cornerRadius = 8
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.isEnabled = false // Initially disabled
+        return button
+    }()
+    
+    private let durationLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.monospacedDigitSystemFont(ofSize: 16, weight: .regular)
+        label.text = "00:00.0"
+        label.textColor = .darkGray
+        label.textAlignment = .center
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .white
+        setupUI()
+        setupViewModelClosures()
+        checkAudioPermissions()
+        
+        // If practiceText was set before viewDidLoad (e.g. by prepareForSegue or direct property set)
+        if viewModel == nil, let text = practiceText {
+             viewModel = PracticeViewModel(practiceText: text)
+             (viewModel?.audioService as? AudioService)?.practiceViewModel = viewModel
+        }
+        configureViewForPracticeText()
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        // Stop any ongoing recording or playback when the view disappears
+        if viewModel?.isRecording ?? false {
+            Task {
+                await viewModel?.toggleRecording() // Stop recording
+            }
+        }
+        viewModel?.stopPlayback() // Stop playback
+    }
+
+    private func setupUI() {
+        view.addSubview(practiceTextView)
+        view.addSubview(recordButton)
+        view.addSubview(durationLabel)
+        view.addSubview(playButton)
+
+        recordButton.addTarget(self, action: #selector(recordButtonPressed), for: .touchUpInside)
+        playButton.addTarget(self, action: #selector(playButtonPressed), for: .touchUpInside)
+
+        NSLayoutConstraint.activate([
+            practiceTextView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 20),
+            practiceTextView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+            practiceTextView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+            practiceTextView.heightAnchor.constraint(equalTo: view.heightAnchor, multiplier: 0.4),
+
+            durationLabel.topAnchor.constraint(equalTo: practiceTextView.bottomAnchor, constant: 20),
+            durationLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            durationLabel.heightAnchor.constraint(equalToConstant: 30),
+
+            recordButton.topAnchor.constraint(equalTo: durationLabel.bottomAnchor, constant: 20),
+            recordButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            recordButton.widthAnchor.constraint(equalToConstant: 200),
+            recordButton.heightAnchor.constraint(equalToConstant: 50),
+
+            playButton.topAnchor.constraint(equalTo: recordButton.bottomAnchor, constant: 20),
+            playButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            playButton.widthAnchor.constraint(equalToConstant: 200),
+            playButton.heightAnchor.constraint(equalToConstant: 50)
+        ])
+    }
+
+    private func configureViewForPracticeText() {
+        guard let viewModel = viewModel, isViewLoaded else { return }
+        navigationItem.title = viewModel.currentPracticeText.title ?? "Practice"
+        practiceTextView.text = viewModel.currentPracticeText.content
+        updateUIForViewModelState()
+    }
+
+    private func setupViewModelClosures() {
+        viewModel?.onRecordingStateChanged = { [weak self] isRecording in
+            self?.updateRecordButtonState(isRecording: isRecording)
+        }
+        
+        viewModel?.onLastRecordingURLChanged = { [weak self] url in
+            self?.updatePlayButtonState(hasRecording: url != nil)
+        }
+        
+        viewModel?.onRecordingDurationChanged = { [weak self] duration in
+            self?.updateDurationLabel(duration: duration)
+        }
+
+        viewModel?.onError = { [weak self] error in
+            // Simple alert for errors
+            let alert = UIAlertController(title: "Error", message: error.localizedDescription, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: "OK", style: .default))
+            self?.present(alert, animated: true)
+        }
+    }
+    
+    private func updateUIForViewModelState() {
+        guard let viewModel = viewModel, isViewLoaded else { return }
+        updateRecordButtonState(isRecording: viewModel.isRecording)
+        updatePlayButtonState(hasRecording: viewModel.lastRecordingURL != nil)
+        updateDurationLabel(duration: viewModel.currentRecordingDuration)
+    }
+
+    private func updateRecordButtonState(isRecording: Bool) {
+        if isRecording {
+            recordButton.setTitle("Stop Recording", for: .normal)
+            recordButton.backgroundColor = .systemOrange // Or another color for "Stop"
+        } else {
+            recordButton.setTitle("Record", for: .normal)
+            recordButton.backgroundColor = .systemRed
+        }
+    }
+
+    private func updatePlayButtonState(hasRecording: Bool) {
+        playButton.isEnabled = hasRecording
+        playButton.alpha = hasRecording ? 1.0 : 0.5
+    }
+    
+    private func updateDurationLabel(duration: TimeInterval) {
+        let minutes = Int(duration) / 60
+        let seconds = Int(duration) % 60
+        let tenths = Int((duration - Double(minutes * 60) - Double(seconds)) * 10)
+        durationLabel.text = String(format: "%02d:%02d.%d", minutes, seconds, tenths)
+    }
+
+    @objc private func recordButtonPressed() {
+        guard let viewModel = viewModel else { return }
+        // If we are about to start recording, first check permissions
+        if !viewModel.isRecording {
+            checkAudioPermissions { [weak self] granted in
+                guard granted else {
+                    self?.showPermissionsAlert()
+                    return
+                }
+                // Permissions granted, proceed with recording
+                Task { // Swift concurrency Task
+                    await self?.viewModel?.toggleRecording()
+                }
+            }
+        } else {
+            // If already recording, just toggle (stop)
+            Task {
+                await viewModel.toggleRecording()
+            }
+        }
+    }
+
+    @objc private func playButtonPressed() {
+        guard let viewModel = viewModel else { return }
+        Task { // Swift concurrency Task
+            await viewModel.playLastRecording()
+        }
+    }
+    
+    // MARK: - Audio Permissions
+    private func checkAudioPermissions(completion: ((Bool) -> Void)? = nil) {
+        switch AVAudioSession.sharedInstance().recordPermission {
+        case .granted:
+            print("Audio permission granted.")
+            completion?(true)
+        case .denied:
+            print("Audio permission denied.")
+            completion?(false)
+        case .undetermined:
+            print("Audio permission undetermined. Requesting...")
+            AVAudioSession.sharedInstance().requestRecordPermission { [weak self] granted in
+                DispatchQueue.main.async {
+                    if granted {
+                        print("Audio permission granted after request.")
+                    } else {
+                        print("Audio permission denied after request.")
+                    }
+                    completion?(granted)
+                }
+            }
+        @unknown default:
+            print("Unknown audio permission state.")
+            completion?(false)
+        }
+    }
+    
+    private func showPermissionsAlert() {
+        let alert = UIAlertController(
+            title: "Microphone Access Denied",
+            message: "SpeakUp needs access to your microphone to record audio. Please enable access in Settings.",
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
+        alert.addAction(UIAlertAction(title: "Settings", style: .default, handler: { _ in
+            if let url = URL(string: UIApplication.openSettingsURLString) {
+                UIApplication.shared.open(url, options: [:], completionHandler: nil)
+            }
+        }))
+        present(alert, animated: true, completion: nil)
+    }
+    
+    deinit {
+        print("PracticeViewController deinitialized.")
+    }
+}
+
+// Helper to make UIFont.monospacedDigitSystemFont available if needed for older iOS versions
+// (though systemFont of size will generally use a good monospaced font for digits if available)
+// For simplicity, the above uses systemFont which is fine for this MVP.

--- a/SpeakUp/SpeakUp/Views/Practice/PracticeViewModel.swift
+++ b/SpeakUp/SpeakUp/Views/Practice/PracticeViewModel.swift
@@ -1,0 +1,168 @@
+import Foundation
+import Combine // For @Published if we decide to use it for bindings
+
+class PracticeViewModel: ObservableObject {
+    private let audioService: AudioService
+    private let recordingRepository: RecordingRepository
+    private let textRepository: TextRepository
+    
+    let currentPracticeText: PracticeText // Passed during initialization
+
+    // @Published can be used if SwiftUI is adopted later or for Combine-based UI updates
+    // For UIKit, we'll use manual updates or closures/delegates from VC.
+    var isRecording: Bool = false {
+        didSet {
+            // This is a good place for a closure/delegate call to update UI if not using Combine's @Published
+            onRecordingStateChanged?(isRecording)
+        }
+    }
+    var lastRecordingURL: URL? {
+        didSet {
+            onLastRecordingURLChanged?(lastRecordingURL)
+        }
+    }
+    var recordingStartTime: Date?
+    var currentRecordingDuration: TimeInterval = 0 {
+        didSet {
+            onRecordingDurationChanged?(currentRecordingDuration)
+        }
+    }
+    private var durationTimer: Timer?
+
+    // Closures for UI updates in ViewController
+    var onRecordingStateChanged: ((Bool) -> Void)?
+    var onLastRecordingURLChanged: ((URL?) -> Void)?
+    var onRecordingDurationChanged: ((TimeInterval) -> Void)?
+    var onError: ((Error) -> Void)? // To communicate errors to the View
+
+    init(practiceText: PracticeText, 
+         audioService: AudioService = AudioService(), 
+         recordingRepository: RecordingRepository = RecordingRepository(),
+         textRepository: TextRepository = TextRepository()) {
+        self.currentPracticeText = practiceText
+        self.audioService = audioService
+        self.recordingRepository = recordingRepository
+        self.textRepository = textRepository
+        
+        // Fetch the most recent recording for this text, if any, to enable playback initially.
+        // For MVP, we could simplify and only allow playback of newly created recordings.
+        // However, this makes it a bit more user-friendly.
+        let existingRecordings = recordingRepository.fetchRecordings(forTextID: practiceText.id, sortByCreatedAt: false)
+        if let mostRecentRecording = existingRecordings.first {
+            self.lastRecordingURL = mostRecentRecording.fileURL
+        }
+    }
+
+    @MainActor
+    func toggleRecording() async {
+        if isRecording {
+            // Stop recording
+            audioService.stopRecording() // This will trigger delegate, which then saves.
+                                        // The actual saving logic is now in the delegate method.
+            // isRecording will be set to false in the delegate method audioRecorderDidFinishRecording
+        } else {
+            // Start recording
+            do {
+                isRecording = true // Set state immediately
+                recordingStartTime = Date()
+                startDurationTimer()
+                let url = try await audioService.startRecording()
+                // This URL is where the recording *will be* once finished.
+                // The actual saving and setting of lastRecordingURL happens in the delegate callback.
+                print("Recording started, will be saved to: \(url.path)")
+            } catch {
+                print("Error starting recording: \(error)")
+                onError?(error)
+                isRecording = false // Reset state on error
+                stopDurationTimer()
+            }
+        }
+    }
+    
+    // This method should be called by AudioService delegate `audioRecorderDidFinishRecording`
+    @MainActor
+    func recordingFinished(url: URL, successfully: Bool) {
+        stopDurationTimer()
+        currentRecordingDuration = 0 // Reset duration display
+        isRecording = false // Update state *after* async operation and delegate call
+
+        guard successfully else {
+            print("Recording finished unsuccessfully.")
+            // Optionally, provide error feedback to the user via onError closure
+            onError?(NSError(domain: "PracticeViewModel", code: 1, userInfo: [NSLocalizedDescriptionKey: "Recording failed."]))
+            return
+        }
+        
+        guard let startTime = recordingStartTime else {
+            print("Error: recordingStartTime was nil. Cannot calculate duration.")
+            onError?(NSError(domain: "PracticeViewModel", code: 2, userInfo: [NSLocalizedDescriptionKey: "Recording start time was missing."]))
+            return
+        }
+        
+        let duration = Date().timeIntervalSince(startTime)
+        self.lastRecordingURL = url // Store the URL of the new recording
+        
+        print("Recording finished. URL: \(url.path), Duration: \(duration)")
+        
+        // Save recording metadata to Core Data
+        _ = recordingRepository.saveRecording(fileURL: url, duration: duration, textID: currentPracticeText.id)
+        
+        // No need to call textRepository.updatePracticeTextStats here as
+        // recordingRepository.saveRecording already calls it.
+    }
+
+    @MainActor
+    func playLastRecording() async {
+        guard let urlToPlay = lastRecordingURL else {
+            print("No recording URL found to play.")
+            onError?(NSError(domain: "PracticeViewModel", code: 3, userInfo: [NSLocalizedDescriptionKey: "No recording available to play."]))
+            return
+        }
+        
+        // Ensure not currently recording before attempting playback
+        if isRecording {
+            print("Cannot play recording while another recording is in progress.")
+            onError?(NSError(domain: "PracticeViewModel", code: 4, userInfo: [NSLocalizedDescriptionKey: "Please stop the current recording before playing."]))
+            return
+        }
+        
+        do {
+            print("Attempting to play recording from URL: \(urlToPlay.path)")
+            try await audioService.playRecording(url: urlToPlay)
+            print("Playback finished.")
+        } catch {
+            print("Error playing last recording: \(error)")
+            onError?(error)
+        }
+    }
+
+    func stopPlayback() {
+        audioService.stopPlaying()
+    }
+    
+    private func startDurationTimer() {
+        durationTimer?.invalidate() // Invalidate existing timer
+        currentRecordingDuration = 0
+        durationTimer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { [weak self] _ in
+            guard let self = self, let startTime = self.recordingStartTime else { return }
+            self.currentRecordingDuration = Date().timeIntervalSince(startTime)
+        }
+    }
+
+    private func stopDurationTimer() {
+        durationTimer?.invalidate()
+        durationTimer = nil
+    }
+    
+    // Call this when the view model is about to be deallocated
+    deinit {
+        stopDurationTimer()
+        // If recording, ensure it's stopped to prevent resource leaks or unexpected behavior
+        if isRecording {
+            audioService.stopRecording()
+        }
+        // If playing, stop playback
+        audioService.stopPlaying()
+        print("PracticeViewModel deinitialized.")
+    }
+}


### PR DESCRIPTION
This pull request sets up the foundation for the `SpeakUp` app by configuring the Xcode project, adding Core Data models, and implementing repositories for managing `PracticeText` and `Recording` entities. The changes include project configuration, Core Data setup, and repository logic for CRUD operations.

### Project Configuration:
* Added the `SpeakUp.xcodeproj` file with initial project settings, including build configurations, groups, and targets. This sets up the structure for the `SpeakUp` app in Xcode.

### Core Data Setup:
* Introduced `PersistenceController` to manage the Core Data stack, including an in-memory option for testing.
* Added the `SpeakUp.xcdatamodeld` file with two entities: `PracticeText` (for practice text data) and `Recording` (for audio recordings), along with their attributes and relationships.

### Repository Implementation:
* Created `TextRepository` to handle CRUD operations for `PracticeText`, including importing sample texts, fetching all texts, and updating practice statistics.
* Created `RecordingRepository` to manage `Recording` entities, including saving, fetching, and deleting recordings, as well as associating them with `PracticeText`.